### PR TITLE
Fixing a few more data representation errors in s3.asm.

### DIFF
--- a/s3.asm
+++ b/s3.asm
@@ -11725,8 +11725,6 @@ Obj_Competition_ZoneSelect:
 locret_9DC0:
 		rts
 ; ---------------------------------------------------------------------------
-
-loc_9DC2:
 		cmpi.w	#-$58,(H_scroll_buffer).w
 		bne.s	loc_9E06
 		tst.w	($FFFFEEE6).w
@@ -12202,7 +12200,7 @@ loc_A1D2:
 		lea	(RAM_start).l,a1
 		movea.w	#$20,a2
 		jsr	KosArt_To_VDP(pc)
-		move.l	#$952E,($FFFFEF44).w
+		move.l	#locret_952E,($FFFFEF44).w
 		move.b	#$1E,(V_int_routine).w
 		jsr	(Wait_VSync).l
 		lea	(ArtKos_CompetitionLevel).l,a0
@@ -12628,7 +12626,7 @@ loc_AA02:
 		lea	(RAM_start).l,a1
 		movea.w	#$20,a2
 		jsr	KosArt_To_VDP(pc)
-		move.l	#$952E,($FFFFEF44).w
+		move.l	#locret_952E,($FFFFEF44).w
 		move.b	#$1E,(V_int_routine).w
 		jsr	(Wait_VSync).l
 		lea	(ArtKos_CompetitionLevel).l,a0

--- a/s3.asm
+++ b/s3.asm
@@ -11725,6 +11725,8 @@ Obj_Competition_ZoneSelect:
 locret_9DC0:
 		rts
 ; ---------------------------------------------------------------------------
+
+loc_9DC2:
 		cmpi.w	#-$58,(H_scroll_buffer).w
 		bne.s	loc_9E06
 		tst.w	($FFFFEEE6).w


### PR DESCRIPTION
In Competition_PlayerSelect, and Competition_Results, there exists a snag which causes any data shifting to cause these game modes to crash to a black screen upon execution. The issue here? The lines changed here used to just move the address to an RAM address. Now they move the actual label. This was already fixed in the other Competition game modes, so me screwing around with S3A and finding this led to this pull request.

Naturally an expansion on pull requests [#28 ](https://github.com/sonicretro/skdisasm/pull/28) and [#29 ](https://github.com/sonicretro/skdisasm/pull/29).