### PR TITLE
Fix opening SSZ2 in SonLVL

### DIFF
--- a/SonLVL INI Files/SSZ/EggMobile.cs
+++ b/SonLVL INI Files/SSZ/EggMobile.cs
@@ -72,7 +72,7 @@ namespace S3KObjectDefinitions.SSZ
 				"../General/Sprites/Robotnik/Map - Robotnik Ship.asm", 10, 0, true);
 
 			var head = ObjectHelper.MapASMToBmp(LevelData.ReadFile(
-				"../General/Sprites/Robotnik/Egg Robo Head.bin", CompressionType.Kosinski),
+				"../General/Sprites/Robotnik/Egg Robo Head.bin", CompressionType.KosinskiM),
 				"../General/Sprites/Robotnik/Map - Egg Robo Head.asm", 0, 0, true);
 
 			var mecha = ObjectHelper.MapASMToBmp(LevelData.ReadFile(


### PR DESCRIPTION
This small change fixes opening Sky Sanctuary Act 2 in SonLVL. A KosM piece was labelled as a regular Kosinski compressed piece, which would seemingly trip up the decompression system used by the editor and render the whole level inaccessible. Older versions of SonLVL would accept it labeled Kos piece, but some change made in the program along the way made this no longer the case.