### PR TITLE
Fix looping bug with Sonic 3s Credits music

### DIFF
--- a/Sound/Music/Credits (Sonic 3).asm
+++ b/Sound/Music/Credits (Sonic 3).asm
@@ -186,12 +186,12 @@ Snd_S3Credits_FM4:
 	smpsCall            Snd_S3Credits_Call00
 	dc.b	nG3, nF3, nFs3, nAb3, nG3, nAb3, nBb3, nC4
 	smpsCall            Snd_S3Credits_Call01
-    if FixMusicAndSFXDataBugs
+    if FixMusicAndSFXDataBugs<>0
 	dc.b	nRst, $02
     endif
 
 Snd_S3Credits_Jump00:
-    if ~FixMusicAndSFXDataBugs
+    if FixMusicAndSFXDataBugs=0
 	; This delay is needed before the song loops to be synced with FM3 and FM5.
 	; However, this makes it delay every loop, causing it to eventually desync
 	; with the rest of the song every loop!

--- a/Sound/Music/Credits (Sonic 3).asm
+++ b/Sound/Music/Credits (Sonic 3).asm
@@ -186,9 +186,17 @@ Snd_S3Credits_FM4:
 	smpsCall            Snd_S3Credits_Call00
 	dc.b	nG3, nF3, nFs3, nAb3, nG3, nAb3, nBb3, nC4
 	smpsCall            Snd_S3Credits_Call01
+    if FixMusicAndSFXDataBugs
+	dc.b	nRst, $02
+    endif
 
 Snd_S3Credits_Jump00:
-	dc.b	nRst, $02, nRst, $60, nRst
+    if ~FixMusicAndSFXDataBugs
+	; this causes this channel to desync with the rest of the song every loop
+	; compare Snd_S3Credits_Jump00 (FM4) to Snd_S3Credits_Jump01 (FM3 and FM5)
+	dc.b	nRst, $02
+    endif
+	dc.b	nRst, $60, nRst
 	smpsAlterPitch      $F4
 	smpsCall            Snd_S3Credits_Call02
 	smpsAlterPitch      $0C

--- a/Sound/Music/Credits (Sonic 3).asm
+++ b/Sound/Music/Credits (Sonic 3).asm
@@ -192,8 +192,10 @@ Snd_S3Credits_FM4:
 
 Snd_S3Credits_Jump00:
     if ~FixMusicAndSFXDataBugs
-	; this causes this channel to desync with the rest of the song every loop
-	; compare Snd_S3Credits_Jump00 (FM4) to Snd_S3Credits_Jump01 (FM3 and FM5)
+	; This delay is needed before the song loops to be synced with FM3 and FM5.
+	; However, this makes it delay every loop, causing it to eventually desync
+	; with the rest of the song every loop!
+	; Compare Snd_S3Credits_Jump00 (FM4) to Snd_S3Credits_Jump01 (FM3 and FM5)
 	dc.b	nRst, $02
     endif
 	dc.b	nRst, $60, nRst


### PR DESCRIPTION
FM4 didn't loop properly, and for a pretty stupid reason.
Before FM4 begins its loop, the intro needs two extra rests before being in sync with FM3 and FM5, but the rests needed for the end of the intro were jumped to when the channel loops, essentially being lumped together with the rests during the start of the loop, making it progressively delay by 2 extra rests per loop. FM3 and FM5 have the exact same start of loop delay, but no end of intro delay, making this issue fairly easy to figure out, even for an SMPS novice like myself.

I personally think that the delay works well for the credits. For a **purely hypothetical** use for a zones music, such as, I dunno, Hidden Palace? Not so much.