### PR TITLE
Add notes to the "Chaos Emerald.asm" and "Countdown.asm" music files, also a bug fix to "Countdown.asm"

### DIFF
--- a/Sound/Music/Chaos Emerald.asm
+++ b/Sound/Music/Chaos Emerald.asm
@@ -44,6 +44,8 @@ Snd_Emerald_FM5:
 	smpsStop
 
 ; FM6 Data
+; There is FM channel 6 data in this song, however the Sonic & Knuckles sound driver doesn't support FM on channel 6, causing it to be silent
+; This is likely a left over from Sonic 1 and 2 where those game's sound drivers do support FM on channel 6
 Snd_Emerald_FM6:
 	smpsSetvoice        $01
 	dc.b	nG5, $0C, nG5, $06, nC6, $06, nRst, nC6, nRst, nE6, $2A

--- a/Sound/Music/Countdown.asm
+++ b/Sound/Music/Countdown.asm
@@ -49,7 +49,13 @@ Snd_Drown_FM3:
 
 Snd_Drown_Loop02:
 	smpsFMAlterVol      $FE
-	dc.b	smpsNoAttack, nC6, $02, smpsNoAttack, nCs6, smpsNoAttack, nC6, smpsNoAttack, nCs6, smpsNoAttack, nC6, smpsNoAttack
+    if ~~FixMusicAndSFXDataBugs
+; Like Sonic 1 and 2, the drowning countdown is supposed to have channel 3 get louder as the song progesses.
+; However in 3/& Knuckles, it remains silent until the very end, this smpsNoAttack command seems to cause the issue.
+; This is likely a SMPS Type 2 driver diffrence commparied to Type 1b, as if you port this version of the drowning countdown to Sonic 1/2 it will work.   
+	dc.b	smpsNoAttack
+    endif	
+	dc.b	nC6, $02, smpsNoAttack, nCs6, smpsNoAttack, nC6, smpsNoAttack, nCs6, smpsNoAttack, nC6, smpsNoAttack
 	dc.b	nCs6, smpsNoAttack, nC6, smpsNoAttack, nCs6
 	smpsLoop            $00, $1E, Snd_Drown_Loop02
 	dc.b	nC6, $0C


### PR DESCRIPTION
While messing around with these files I noticed two things regarding "Chaos Emerald.asm" and "Countdown.asm"

Chaos Emerald: Attempts to use the 6th FM channel on a driver that doesn't support it.

Countdown: The 3rd FM channel doesn't play correctly due to I think a difference between SMPS Type 2 and Type 1b (I feel like both of these tracks were more or less ported from S1/2 to S3 without too much thought) 

I do feel like the bugfix I did could be improved upon by someone more knowledge with SMPS. so if anyone wants to do that, go wild.
