### PR TITLE
Document smpsNop in S3 alone and S&K

### DIFF
--- a/Sound/Music/Chaos Emerald.asm
+++ b/Sound/Music/Chaos Emerald.asm
@@ -63,7 +63,7 @@ Snd_Emerald_Loop01:
 
 ; PSG1 Data
 Snd_Emerald_PSG1:
-	smpsFade            $01
+	smpsNop             $01
 	dc.b	nRst, $02, nRst, $2D
 
 Snd_Emerald_Loop00:

--- a/Sound/Music/Countdown.asm
+++ b/Sound/Music/Countdown.asm
@@ -17,7 +17,7 @@ Snd_Drown_Header:
 ; FM1 Data
 Snd_Drown_FM1:
 	smpsSetvoice        $00
-	smpsFade            $01
+	smpsNop             $01
 	smpsNoteFill        $03
 	smpsCall            Snd_Drown_Call01
 	smpsSetTempoMod     $40
@@ -29,7 +29,7 @@ Snd_Drown_FM1:
 	smpsSetTempoMod     $08
 	smpsCall            Snd_Drown_Call01
 	dc.b	nC5, $0C
-	smpsFade            $01
+	smpsNop             $01
 	smpsStop
 
 ; FM2 Data

--- a/Sound/Music/Credits (Sonic & Knuckles).asm
+++ b/Sound/Music/Credits (Sonic & Knuckles).asm
@@ -1088,7 +1088,7 @@ Snd_SKCredits_Loop34:
 
 ; DAC Data
 Snd_SKCredits_DAC:
-	smpsFade            $00
+	smpsNop             $00
 	dc.b	nRst, $02, dElectricHighTom, $04, $04, $04, dElectricMidTom, $05, dElectricMidTom, $06, dElectricLowTom, nRst
 	dc.b	nRst, nRst, $05, dCrashCymbal, $12, dKickS3, dKickS3, $18, $06, $06, dSnareS3, $0C
 	dc.b	dCrashCymbal, nRst, dKickS3, nRst, $06, dKickS3, nRst, $0C, dKickS3, $18, dSnareS3, dCrashCymbal
@@ -1199,7 +1199,7 @@ Snd_SKCredits_Loop06:
 	dc.b	$06, $06, nRst, nRst, dKickS3, $18, dSnareS3, dKickS3, $06, dKickS3, dKickS3, $0C
 	dc.b	dSnareS3, $18, dKickS3, $18, dSnareS3, $12, dKickS3, $06, dKickS3, dKickS3, dKickS3, $0C
 	dc.b	dSnareS3, dCrashCymbal, $60, nRst, $60
-	smpsFade            $01
+	smpsNop             $01
 	smpsStop
 
 Snd_SKCredits_Voices:

--- a/Sound/Music/Game Complete (Sonic & Knuckles).asm
+++ b/Sound/Music/Game Complete (Sonic & Knuckles).asm
@@ -177,7 +177,7 @@ Snd_PresSega_PSG3:
 
 ; DAC Data
 Snd_PresSega_DAC:
-	smpsFade            $25
+	smpsNop             $25
 	dc.b	dCrashCymbal, $30, nRst, $0C, dSnareS3, dSnareS3, dSnareS3, $06, $06, dCrashCymbal, $18, dSnareS3
 	dc.b	$0C, dKickS3, dKickS3, $06, dKickS3, dKickS3, $0C, dSnareS3, $18, dKickS3, $18, dSnareS3
 	dc.b	$0C, dKickS3, dKickS3, $06, dKickS3, dKickS3, $0C, dSnareS3, $06, $06, nRst, nRst

--- a/Sound/Music/Game Complete (Sonic 3).asm
+++ b/Sound/Music/Game Complete (Sonic 3).asm
@@ -212,7 +212,7 @@ Snd_S3_PresSega_Loop05:
 
 ; DAC Data
 Snd_S3_PresSega_DAC:
-	smpsFade            $25
+	smpsNop             $25
 	dc.b	dCrashCymbal, $30, nRst, $06, dSnareS3, dSnareS3, $06, nRst, dSnareS3, nRst, dSnareS3, dSnareS3
 	dc.b	dKickS3, $18, dSnareS3, dKickS3, dSnareS3, dKickS3, dSnareS3, dKickS3, dSnareS3, $06, nRst, nRst
 	dc.b	dSnareS3, $06, dKickS3, $18, dSnareS3, dKickS3, dSnareS3, dKickS3, dSnareS3, $06, nRst, nRst

--- a/Sound/_smps2asm_inc.asm
+++ b/Sound/_smps2asm_inc.asm
@@ -389,10 +389,9 @@ smpsDetune macro val
 	endm
 
 ; E2xx - Useless
+; In S3 alone and S&K, the value afterwards must be $FF, otherwise the fade command will be completely ignored
 smpsNop macro val
-	if SonicDriverVer<3
 		dc.b	$E2,val
-	endif
 	endm
 
 ; Return (used after smpsCall)


### PR DESCRIPTION
In Sonic 3 Alone and Sonic & Knuckles, the fade flag in SMPS will only work if the value afterwards is set to $FF. This in turn means that anything that is not $FF will make the fade flag completely redundant and it will act as a nop.