### PR TITLE
Controller constants, additional comments, and more

### DIFF
--- a/s3.asm
+++ b/s3.asm
@@ -1710,7 +1710,7 @@ Pause_Loop:
 		beq.s	Pause_NoSlowMo
 		btst	#button_A,(Ctrl_1_pressed).w
 		beq.s	Pause_ChkFrameAdvance	; branch if A isn't pressed
-		move.b	#$28,(Game_mode).w	; go to level select (oddly enough this is only for Sonic 3 Alone, Sonic 2, the Nov 3rd 1993 Prototype and Sonic & Knuckles do not have it set to go to the level select)
+		move.b	#$28,(Game_mode).w	; go to level select (oddly enough this is only for Sonic 3 Alone, Sonic 2, the Nov 3rd 1993 Prototype and Sonic & Knuckles do not have it set to go to the level select. This line was eventually changed to go back to the title screen once more by the 0610 build of Sonic & Knuckles.)
 		nop
 		bra.s	Pause_ResumeMusic
 ; ---------------------------------------------------------------------------


### PR DESCRIPTION
This commit documents and re-formats hex integers into decimal integers for easier readability for tilemaps and some deformation data as well. The most interesting things to note here is that Sonic 3 Alone's slow motion flag when pressing A actually returns you to the level select instead of the title screen unlike Sonic 2, Sonic 3's Nov 3rd 1993 Prototype, and Sonic & Knuckles which I found really fascinating and peaked my interest. Another thing to note is the way that the sound driver is loaded in Sonic 3 Alone, it actually loads a lot of padding data rather than the actual size of the Z80 sound driver altogether, although it doesn't actually conflict with anything so I didn't think it warranted a bug fix since it does not affect the Z80's RAM.