### PR TITLE
Fix SonLVL HCZ Button obj def

### DIFF
--- a/SonLVL INI Files/Common/Button.cs
+++ b/SonLVL INI Files/Common/Button.cs
@@ -11,7 +11,7 @@ namespace S3KObjectDefinitions.HCZ
 		public override void Init(ObjectData data)
 		{
 			BuildSpritesProperties("../Levels/HCZ/Nemesis Art/Button.bin",
-				"../General/Sprites/Buttons/Map - Button 2.asm", null, 1);
+				"../Levels/HCZ/Misc Object Data/Map - Button.asm", null, 1);
 		}
 	}
 }


### PR DESCRIPTION
In 65bbce67f72c995888f9aa7ca9f8c79f727fec0f, the mappings file for the HCZ Button got renamed. However, the SonLVL object definition for it was never updated, leading to a crash whenever attempting to load HCZ.